### PR TITLE
refactor: add Deno compilerOptions

### DIFF
--- a/app/header.tsx
+++ b/app/header.tsx
@@ -1,5 +1,3 @@
-/// <reference lib="dom" />
-
 import React from "react";
 
 export interface Props {

--- a/app/todo_item.tsx
+++ b/app/todo_item.tsx
@@ -1,5 +1,3 @@
-/// <reference lib="dom" />
-
 import React from "react";
 import classNames from "class-names";
 

--- a/deno.json
+++ b/deno.json
@@ -3,5 +3,8 @@
   "tasks": {
     "build": "deno run -A https://deno.land/x/lume@v1.9.1/ci.ts",
     "serve": "deno task build -s"
+  },
+  "compilerOptions": {
+    "lib": ["dom", "dom.iterable", "dom.asynciterable", "deno.ns"]
   }
 }


### PR DESCRIPTION
According to the [Deno docs](https://deno.land/manual/typescript/configuration#targeting-deno-and-the-browser), the compiler option is added, and remove the `<reference lib="dom" />`